### PR TITLE
create migration table for models

### DIFF
--- a/database/migrations/2020_11_11_103635_users.php
+++ b/database/migrations/2020_11_11_103635_users.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class Users extends Migration
+{
+    private $table_name = 'users';
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create($this->table_name, function (Blueprint $table) {
+            $table->id();
+            $table->string('email');
+            $table->string('password');
+            $table->boolean('is_admin');
+            $table->boolean('is_login');
+            $table->foreignId('employee_id')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop($this->table_name);
+    }
+}

--- a/database/migrations/2020_11_11_105427_notifications.php
+++ b/database/migrations/2020_11_11_105427_notifications.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class Notifications extends Migration
+{
+    private $table_name = 'notifications';
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create($this->table_name, function (Blueprint $table) {
+            $table->id();
+            $table->string('message');
+            $table->boolean('is_read');
+            $table->foreignId('user_id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop($this->table_name);
+    }
+}

--- a/database/migrations/2020_11_11_105646_emails.php
+++ b/database/migrations/2020_11_11_105646_emails.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class Emails extends Migration
+{
+    private $table_name = 'emails';
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create($this->table_name, function (Blueprint $table) {
+            $table->longText('message');
+            $table->foreignId('sender_id');
+            $table->foreignId('receiver_id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop($this->table_name);
+    }
+}

--- a/database/migrations/2020_11_11_110040_timesheets.php
+++ b/database/migrations/2020_11_11_110040_timesheets.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class Timesheets extends Migration
+{
+    private $table_name = 'timesheets';
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create($this->table_name, function (Blueprint $table) {
+            $table->id();
+            $table->boolean('is_approved');
+            $table->foreignId('user_id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop($this->table_name);
+    }
+}

--- a/database/migrations/2020_11_11_110654_activities.php
+++ b/database/migrations/2020_11_11_110654_activities.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class Activities extends Migration
+{
+    private $table_name = 'activities';
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create($this->table_name, function (Blueprint $table) {
+            $table->id();
+            $table->string('desc');
+            $table->time('start_time');
+            $table->time('stop_time');
+            $table->foreignId('timesheet_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop($this->table_name);
+    }
+}

--- a/database/migrations/2020_11_11_111328_employees.php
+++ b/database/migrations/2020_11_11_111328_employees.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class Employees extends Migration
+{
+    private $table_name = 'employees';
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create($this->table_name, function (Blueprint $table) {
+            $table->id();
+            $table->string('first_name');
+            $table->string('mid_name');
+            $table->string('last_name');
+            $table->string('phone');
+            $table->enum('gender', ['M', 'F', 'U']);
+            $table->date('birthday');
+            $table->bigInteger('salary');
+            $table->string('job_position');
+            $table->float('rating');
+            $table->foreignId('user_id');
+            $table->foreignId('image_id');
+            $table->foreignId('address_id');
+            $table->foreignId('supervisor_id');
+            $table->foreignId('department_id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop($this->table_name);
+    }
+}

--- a/database/migrations/2020_11_11_112116_departments.php
+++ b/database/migrations/2020_11_11_112116_departments.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class Departments extends Migration
+{
+    private $table_name = 'departments';
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create($this->table_name, function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('code');
+            $table->foreignId('chairman_id');
+            $table->foreignId('office_id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop($this->table_name);
+    }
+}

--- a/database/migrations/2020_11_11_112359_offices.php
+++ b/database/migrations/2020_11_11_112359_offices.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class Offices extends Migration
+{
+    private $table_name = 'offices';
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::drop($this->table_name, function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->time('opening_time');
+            $table->time('closing_time');
+            $table->string('building');
+            $table->boolean('is_branch');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop($this->table_name);
+    }
+}

--- a/database/migrations/2020_11_11_112707_images.php
+++ b/database/migrations/2020_11_11_112707_images.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class Images extends Migration
+{
+    private $table_name = 'images';
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create($this->table_name, function (Blueprint $table) {
+            $table->id();
+            $table->string('alt');
+            $table->string('link');
+            $table->string('url');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop($this->table_name);
+    }
+}

--- a/database/migrations/2020_11_11_113021_addresses.php
+++ b/database/migrations/2020_11_11_113021_addresses.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class Addresses extends Migration
+{
+    private $table_name = 'addresses';
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create($this->table_name, function (Blueprint $table) {
+            $table->id();
+            $table->string('country');
+            $table->string('province');
+            $table->string('city');
+            $table->string('subdistrict');
+            $table->string('postal_code');
+            $table->string('street');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop($this->table_name);
+    }
+}


### PR DESCRIPTION
# Background
Untuk mempermudah migrasi skema dan tabel dari suatu database, dibutuhkan suatu strategi migrasi. Lumen telah menyediakan cara migrasi yang mudah yaitu dengan menggunakan command `php artisan make:migration`. 

# Changes
- Menambahkan file migrasi untuk tabel users, notifications, emails, timesheets, activities, employees, departments, offices, images, addresses

# How To Run
Jalankan migrasi dengan command `php artisan migrate:fresh` . Pastikan untuk menggunakan postfix *:fresh* agar table selalu menyesuaikan ke perubahan paling terbaru